### PR TITLE
Catch test failures not caused by Xunit assertions

### DIFF
--- a/Engine/Program.cs
+++ b/Engine/Program.cs
@@ -91,15 +91,12 @@ namespace DotNetCoreKoans.Engine
             }
             catch (TargetInvocationException e)
             {
-                if (e.InnerException is XunitException)
-                {
-                    Report(koan, e.InnerException as XunitException);
-                    KOAN_FAILED = 1;
-                }
+                Report(koan, e.InnerException);
+                KOAN_FAILED = 1;
             }
         }
 
-        private static void Report(MethodInfo koan, XunitException e = null)
+        private static void Report(MethodInfo koan, Exception e = null)
         {
             if (e != null)
             {


### PR DESCRIPTION
Not all tests fail as a result of Xunit assertions. An example of this
is `AboutNull.AWayNotToCheckThatAnObjectIsNull()` which throws a
`NullReferenceException` before the assertion can be checked. The test
failure is squelched and silently ignored as a result of the
unsuccessful soft cast to the expected `XunitException`. By removing
the cast we can catch any test failure while preserving relevant
reporting details.