### PR TITLE
null is object is false

### DIFF
--- a/Koans/AboutNull.cs
+++ b/Koans/AboutNull.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using DotNetCoreKoans.Engine;
-using System.Reflection;
 
 namespace DotNetCoreKoans.Koans
 {
@@ -9,7 +8,10 @@ namespace DotNetCoreKoans.Koans
         [Step(1)]
         public void NullIsNotAnObject()
         {
-            Assert.True(typeof(object).IsAssignableFrom(null)); //not everything is an object
+            Assert.True(null is object);
+
+            // The `is` operator returns false if the object (first parameter)
+            // is null, no matter what the type (second parameter) is.
         }
 
         [Step(2)]


### PR DESCRIPTION
Fixes #15

Unfortunately `null is object` gives a compile warning. It's suppressed in `project.json`, but it still shows up in the editor. Probably a bug in Visual Studio Code.