### PR TITLE
Issue: 29 Verbatim and literal string inequality when dealing with escaped characters

### DIFF
--- a/Koans/AboutStrings.cs
+++ b/Koans/AboutStrings.cs
@@ -61,9 +61,14 @@ namespace DotNetCoreKoans.Koans
             var verbatimString = @"I
 am a
 broken line";
+
+            // Make sure to use a literal string.
+            // Escaped characters in verbatim strings are covered later.
             var literalString = FILL_ME_IN;
             Assert.Equal(FILL_ME_IN, verbatimString.Length);
             Assert.Equal(literalString, verbatimString);
+
+
         }
 
         [Step(7)]

--- a/Koans/AboutStrings.cs
+++ b/Koans/AboutStrings.cs
@@ -24,7 +24,7 @@ namespace DotNetCoreKoans.Koans
         public void SingleQuotedStringsAreNotStrings()
         {
             var str = 'H';
-			Assert.Equal(typeof(FillMeIn), str.GetType());
+            Assert.Equal(typeof(FillMeIn), str.GetType());
         }
 
         [Step(3)]
@@ -67,8 +67,6 @@ broken line";
             var literalString = FILL_ME_IN;
             Assert.Equal(FILL_ME_IN, verbatimString.Length);
             Assert.Equal(literalString, verbatimString);
-
-
         }
 
         [Step(7)]
@@ -133,110 +131,110 @@ broken line";
             //when dealing with lots of concatenation
         }
 
-		[Step(12)]
-		public void YouDoNotNeedConcatenationToInsertVariablesInAString()
-		{
-			var world = "World";
-			var str = String.Format("Hello, {0}", world);
-			Assert.Equal(FILL_ME_IN, str);
-		}
+        [Step(12)]
+        public void YouDoNotNeedConcatenationToInsertVariablesInAString()
+        {
+            var world = "World";
+            var str = String.Format("Hello, {0}", world);
+            Assert.Equal(FILL_ME_IN, str);
+        }
 
-		[Step(13)]
-		public void AnyExpressionCanBeUsedInFormatString()
-		{
-			var str = String.Format("The square root of 9 is {0}", Math.Sqrt(9));
-			Assert.Equal(FILL_ME_IN, str);
-		}
+        [Step(13)]
+        public void AnyExpressionCanBeUsedInFormatString()
+        {
+            var str = String.Format("The square root of 9 is {0}", Math.Sqrt(9));
+            Assert.Equal(FILL_ME_IN, str);
+        }
 
-		[Step(14)]
-		public void StringsCanBePaddedToTheLeft()
-		{
-			//You can modify the value inserted into the result
-			var str = string.Format("{0,3:}", "x");
-			Assert.Equal(FILL_ME_IN, str);
-		}
+        [Step(14)]
+        public void StringsCanBePaddedToTheLeft()
+        {
+            //You can modify the value inserted into the result
+            var str = string.Format("{0,3:}", "x");
+            Assert.Equal(FILL_ME_IN, str);
+        }
 
-		[Step(15)]
-		public void StringsCanBePaddedToTheRight()
-		{
-			var str = string.Format("{0,-3:}", "x");
-			Assert.Equal(FILL_ME_IN, str);
-		}
+        [Step(15)]
+        public void StringsCanBePaddedToTheRight()
+        {
+            var str = string.Format("{0,-3:}", "x");
+            Assert.Equal(FILL_ME_IN, str);
+        }
 
-		[Step(16)]
-		public void SeperatorsCanBeAdded()
-		{
-			var str = string.Format("{0:n}", 123456);
-			Assert.Equal(FILL_ME_IN, str);
-		}
+        [Step(16)]
+        public void SeperatorsCanBeAdded()
+        {
+            var str = string.Format("{0:n}", 123456);
+            Assert.Equal(FILL_ME_IN, str);
+        }
 
-		[Step(17)]
-		public void CurrencyDesignatorsCanBeAdded()
-		{
-			var str = string.Format("{0:c}", 123456);
-			Assert.Equal(FILL_ME_IN, str);
-		}
+        [Step(17)]
+        public void CurrencyDesignatorsCanBeAdded()
+        {
+            var str = string.Format("{0:c}", 123456);
+            Assert.Equal(FILL_ME_IN, str);
+        }
 
-		[Step(18)]
-		public void NumberOfDisplayedDecimalsCanBeControled()
-		{
-			var str = string.Format("{0:.##}", 12.3456);
-			Assert.Equal(FILL_ME_IN, str);
-		}
+        [Step(18)]
+        public void NumberOfDisplayedDecimalsCanBeControled()
+        {
+            var str = string.Format("{0:.##}", 12.3456);
+            Assert.Equal(FILL_ME_IN, str);
+        }
 
-		[Step(19)]
-		public void MinimumNumberOfDisplayedDecimalsCanBeControled()
-		{
-			var str = string.Format("{0:.00}", 12.3);
-			Assert.Equal(FILL_ME_IN, str);
-		}
+        [Step(19)]
+        public void MinimumNumberOfDisplayedDecimalsCanBeControled()
+        {
+            var str = string.Format("{0:.00}", 12.3);
+            Assert.Equal(FILL_ME_IN, str);
+        }
 
-		[Step(20)]
-		public void BuiltInDateFormaters()
-		{
-			var str = string.Format("{0:t}", DateTime.Parse("12/16/2011 2:35:02 PM", CultureInfo.InvariantCulture));
-			Assert.Equal(FILL_ME_IN, str);
-		}
+        [Step(20)]
+        public void BuiltInDateFormaters()
+        {
+            var str = string.Format("{0:t}", DateTime.Parse("12/16/2011 2:35:02 PM", CultureInfo.InvariantCulture));
+            Assert.Equal(FILL_ME_IN, str);
+        }
 
-		[Step(21)]
-		public void CustomDateFormaters()
-		{
-			var str = string.Format("{0:t m}", DateTime.Parse("12/16/2011 2:35:02 PM", CultureInfo.InvariantCulture));
-			Assert.Equal(FILL_ME_IN, str);
-		}
-		//These are just a few of the formatters available. Dig some and you may find what you need.
+        [Step(21)]
+        public void CustomDateFormaters()
+        {
+            var str = string.Format("{0:t m}", DateTime.Parse("12/16/2011 2:35:02 PM", CultureInfo.InvariantCulture));
+            Assert.Equal(FILL_ME_IN, str);
+        }
+        //These are just a few of the formatters available. Dig some and you may find what you need.
 
         [Step(22)]
         public void ABetterWayToConcatenateLotsOfStrings()
         {
             //Concatenating lots of strings is a Bad Idea(tm). If you need to do that, then consider StringBuilder.
             var strBuilder = new System.Text.StringBuilder();
-			strBuilder.Append("The ");
-			strBuilder.Append("quick ");
-			strBuilder.Append("brown ");
-			strBuilder.Append("fox ");
-			strBuilder.Append("jumped ");
-			strBuilder.Append("over ");
-			strBuilder.Append("the ");
-			strBuilder.Append("lazy ");
-			strBuilder.Append("dog.");
+            strBuilder.Append("The ");
+            strBuilder.Append("quick ");
+            strBuilder.Append("brown ");
+            strBuilder.Append("fox ");
+            strBuilder.Append("jumped ");
+            strBuilder.Append("over ");
+            strBuilder.Append("the ");
+            strBuilder.Append("lazy ");
+            strBuilder.Append("dog.");
             var str = strBuilder.ToString();
             Assert.Equal(FILL_ME_IN, str);
 
             //String.Format and StringBuilder will be more efficent that concatenation. Prefer them.
         }
 
-		[Step(22)]
-		public void StringBuilderCanUseFormatAsWell()
-		{
-			var strBuilder = new System.Text.StringBuilder();
-			strBuilder.AppendFormat("{0} {1} {2}", "The", "quick", "brown");
-			strBuilder.AppendFormat("{0} {1} {2}", "jumped", "over", "the");
-			strBuilder.AppendFormat("{0} {1}.", "lazy", "dog");
-			var str = strBuilder.ToString();
-			Assert.Equal(FILL_ME_IN, str);
-		}
-		
+        [Step(22)]
+        public void StringBuilderCanUseFormatAsWell()
+        {
+            var strBuilder = new System.Text.StringBuilder();
+            strBuilder.AppendFormat("{0} {1} {2}", "The", "quick", "brown");
+            strBuilder.AppendFormat("{0} {1} {2}", "jumped", "over", "the");
+            strBuilder.AppendFormat("{0} {1}.", "lazy", "dog");
+            var str = strBuilder.ToString();
+            Assert.Equal(FILL_ME_IN, str);
+        }
+
         [Step(23)]
         public void LiteralStringsInterpretsEscapeCharacters()
         {
@@ -315,7 +313,7 @@ broken line";
         {
             var name = "John Doe";
             var age = 33;
-            var str= $"Mr. {name} is {age} years old";
+            var str = $"Mr. {name} is {age} years old";
             Assert.Equal(FILL_ME_IN, str);
         }
     }


### PR DESCRIPTION
- Add a hint to why literal and verbatim strings could be seen as unequal but print the same output in the error output. 

- Format the indentation in AboutStrings.cs with vs-code's auto-formatter. 

https://github.com/NotMyself/DotNetCoreKoans/issues/29