### PR TITLE
Test result of LINQ operation

### DIFF
--- a/Koans/AboutLinq.cs
+++ b/Koans/AboutLinq.cs
@@ -52,7 +52,8 @@ namespace DotNetCoreKoans.Koans
                  orderby cust ascending //You can also use descending here for reverse order.
                  select cust;
 
-            Assert.Equal(FILL_ME_IN, customers[0]);
+            Assert.Equal(FILL_ME_IN, orderedCustomers.First());
+            Assert.Equal(FILL_ME_IN, orderedCustomers.Last());
         }
 
         [Step(3)]


### PR DESCRIPTION
I'm going through the koans at the moment as a C# novice, and I noticed that the `PutYourDataInOrderUsingOrderBy` koan was testing the original list, not the result of the `orderedCustomers` operation. 

Apologies if I got the wrong end of the stick here (as I say, I'm a C# novice), but this seemed to be the right thing to test.