### PR TITLE
Remove explicit watcher tools reference to resolve runtime warning

### DIFF
--- a/DotNetCoreKoans.csproj
+++ b/DotNetCoreKoans.csproj
@@ -19,10 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
   </ItemGroup>
 
-  <ItemGroup>    
-    <DotNetCliToolReference Include="microsoft.dotnet.watcher.tools" Version="2.0.0" />
-  </ItemGroup>
-
   <PropertyGroup>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>


### PR DESCRIPTION
The watcher tools are now bundled with the .NET Core SDK, so this explicit reference is unnecessary. The warning text when running the koans references [this page](https://docs.microsoft.com/en-us/dotnet/core/migration/20-21) in the .NET Core documentation to resolve this. Resolves #59 