### PR TITLE
Enable AboutDelegates koans 

### DIFF
--- a/Koans/PathToEnlightenment.cs
+++ b/Koans/PathToEnlightenment.cs
@@ -19,13 +19,10 @@ namespace DotNetCoreKoans.Koans
                 typeof(AboutMethods),
                 typeof(AboutControlStatements),
                 typeof(AboutGenericContainers),
+                typeof(AboutDelegates),
                 typeof(AboutLambdas),
                 typeof(AboutLinq),
-        typeof(AboutBitwiseAndShiftOperator)
-                //TODO: disabled due to missing functionality in netcoreapp1.0
-                // it will be available in 1.1 see:
-                // https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/Array.cs#L1005
-                //typeof(AboutDelegates)
+                typeof(AboutBitwiseAndShiftOperator)
                 };
         } 
     }


### PR DESCRIPTION
As the required features are now in recommended versions of DotNetCore SDK these koans can be used again. 

It also means the comments at the top of AboutLambdas is less confusing if the user hadn't looked at the PathToEnlightenment.cs file and it's comments and therefore seen why AboutDelegates wasn't available.