### PR TITLE
Add Koan About True and False

### DIFF
--- a/Koans/AboutBooleans.cs
+++ b/Koans/AboutBooleans.cs
@@ -1,0 +1,59 @@
+﻿using Xunit;
+using DotNetCoreKoans.Engine;
+using System;
+
+namespace DotNetCoreKoans.Koans
+{
+    public class AboutBooleans : Koan
+    {
+        // The bool type represents boolean logical quantities.
+        // The only possible values of bool are true and false.
+        // No standard conversions exists between bool and other types.
+        // bool is a simple type and is a Alias of System.Boolean, these
+        // can be used interchangeably.
+
+        [Step(1)]
+        public void TrueIsTreatedAsTrue()
+        {
+            // true is true
+            Assert.Equal(true, FILL_ME_IN);
+        }
+
+        [Step(2)]
+        public void FalseIsTreatedAsFalse()
+        {
+            // false is false
+            Assert.Equal(false, FILL_ME_IN);
+        }
+
+        [Step(3)]
+        public void TrueIsNotFalse()
+        {
+            // true is not false
+            Assert.NotEqual(true, FILL_ME_IN);
+        }
+
+        [Step(4)]
+        public void BoolIsAReservedWordOfSystemBoolean()
+        {
+            // bool is a Alias of System.Boolean
+            Assert.Equal(typeof(System.Boolean), typeof(FillMeIn));
+
+        [Step(5)]
+        public void NoOtherTypeConvertsToBool()
+        {
+            var otherTypes = new object[]
+            {
+                "not a bool",
+                1, 0,
+                null,
+                new object[0]
+            };
+
+            foreach(var otherType in otherTypes)
+            {
+                Assert.True(otherType is bool); // no other type can cast to bool
+            }
+        }
+    }
+}

--- a/Koans/PathToEnlightenment.cs
+++ b/Koans/PathToEnlightenment.cs
@@ -9,6 +9,7 @@ namespace DotNetCoreKoans.Koans
     {
       Types = new Type[] {
         typeof(AboutAsserts),
+        typeof(AboutBooleans),
         typeof(AboutNull),
         typeof(AboutArrays),
         typeof(AboutArrayAssignment),
@@ -24,7 +25,7 @@ namespace DotNetCoreKoans.Koans
         typeof(AboutLinq),
         typeof(AboutBitwiseAndShiftOperator),
         typeof(AboutGlobalization)
-                };
+      };
     }
   }
 }


### PR DESCRIPTION
This PR adds a Koan about `bool` in C#.

Fixes #79 