### PR TITLE
Fix to mis-named variables in Enumeration Koan

### DIFF
--- a/Koans/AboutEnumerations.cs
+++ b/Koans/AboutEnumerations.cs
@@ -76,8 +76,8 @@ namespace DotNetCoreKoans.Koans
                   Note that the associated constant value of members start with zero
                   and increase by one.
                   */
-                  var forestPlanet = (MeditationForms)1;
-                  Assert.Equal(FILL_ME_IN, forestPlanet);
+                  var quietForm = (MeditationForms)1;
+                  Assert.Equal(FILL_ME_IN, quietForm);
 
                   /*
                   Why would casting integers to enums be valuable? You may want to
@@ -85,7 +85,7 @@ namespace DotNetCoreKoans.Koans
                   an integer and when querying for those values, you'd be handed an
                   integer back. For instance:
 
-                  var usersHomePlanet = (Planets)row['planet'];
+                  var usersPreferredForm = (MeditationForms)row['usersPreferredForm'];
 
                   Handling integer values as enumerations improves readability.
                   */


### PR DESCRIPTION
Request to fix a missed variable name change recommendation from a previous PR.

This is a little embarrassing but I missed renaming this variable and the PR went through. I think leaving the variable name as is will cause some confusion. The second instance of renaming is just an example in a comment, but should be fixed as well.

Sorry for not being more attentive on this and spending more of your time.