### PR TITLE
Disable formatOnSave for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
-  "editor.minimap.enabled": false,
-  "editor.formatOnSave": true
+  "editor.minimap.enabled": false
 }


### PR DESCRIPTION
If local user settings are different than yours it will produce Wall of Pink like it did for me https://github.com/cestrand/DotNetCoreKoans/commit/c8ed339ff1b1d50c28aa355de6607415cbf61f74

In my case tab space adjustment would help but I couldn't notice it from VSCode perspective as whitespace discrepancy was not highlighted in diff view. Koans students will have mess in their repositories.
